### PR TITLE
updated resources.md showing levels #19

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -1,15 +1,112 @@
-Resource | Source | Description 
+## Scala Community
+The "official" [Scala Community page](http://www.scala-lang.org/community/) lists popular ways to connect with the Scala community including:
+- Mailing Lists
+- Chat Rooms
+- User Groups
+- Conferences
+- Stack Overflow
+- Reddit
+- Sources of Scala News
+- Community-powered learning resources
+- Community Libraries and Tools
+
+## Additional Resources
+The learning resources provided below are classified two ways:
+* by **cost**:
+	* Free
+	* Paid
+* by **learning level** required:
+	* Intro - no prior experience is required
+	* Intermediate - you know the basics
+	* Advanced - you know the language or where to get help
+
+While the learning level shown is the suggested starting knowledge level for the resource, the resource may contain a progression of material that covers more advanced topics.
+
+## Free Introductory Resources
+Resource | Source | Description
 ---|---|---
-[Scala Exercises](https://www.scala-exercises.org/) | [47 degrees](http://www.47deg.com/) | Scala Exercises is an Open Source project for learning different technologies based in the Scala Programming Language. Currently covers Standard, Cats, and Shapeless libraries, and can be extended to others | intermediate
-[Coursera Scala Specialization](https://www.coursera.org/specializations/scala) | [Scala Center](https://scala.epfl.ch/) | A new Scala mini-degree offered on Coursera. Composed of: 4 courses, one capstone project - A significant 4-5 week long final programming project. Note: only the first 3 courses are currently available.
-[Scala School](https://twitter.github.io/scala_school/)| [Twitter](https://twitter.com) | "From ∅ to Distributed Service - ...teaching Scala not as if it were an improved Java but instead as a new language." Most of the lessons require no software other than a Scala REPL.
-[Effective Scala](http://twitter.github.io/effectivescala/) | [Twitter](https://twitter.com) | Twitter's "best practices" for Scala. Useful for understanding idioms in Twitter's code.  
-[Creative Scala](http://underscore.io/training/courses/creative-scala/) | [Underscore](http://underscore.io/) | Creative Scala is aimed at developers who have no prior experience in Scala. It is designed to give you a fun introduction to functional programming. The course textbook is free, complete with exercises and solutions.
-[Atomic Scala](http://www.atomicscala.com/) |[Mindview](http://www.mindviewinc.com/Index.php) | This book teaches the Scala language to both programming beginners and those who have already programmed in another language. The first 100+ pages of the book are available as a PDF download.
-[Scala for the Impatient](http://horstmann.com/scala/) | [Cay S. Horstmann](http://horstmann.com/) | A rapid introduction to Scala for programmers who are competent in Java, C#, or C++. “Currently the best compact introduction to Scala” —Martin Odersky [Lightbend](https://www.lightbend.com/resources/e-book/scala-for-the-impatient) provides a free download of Chapters 1-11, 139 pages.
-[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala) | [Paul Chiusano](https://pchiusano.github.io/) and [Rúnar Bjarnason](http://blog.higher-order.com/) | Functional Programming in Scala is a serious tutorial for programmers looking to learn FP and apply it to the everyday business of coding. [Lightbend](https://www.lightbend.com/resources/e-book/functional-programming-in-scala) provides 2 sample chapters for free and a promotional 40% off the purchase price at Manning.
-[Programming in Scala, 1st Edition](http://www.artima.com/pins1ed/) - free online | [Martin Odersky](https://en.wikipedia.org/wiki/Martin_Odersky), [Lex Spoon](http://www.lexspoon.org/), and [Bill Venners](http://www.scala-lang.org/blog/2016/04/29/sc-community-representative.html) | The "Stairway" Book - This book is the authoritative tutorial on the Scala programming language, co-written by the language's designer, Martin Odersky. The main target audience for this book is programmers who want to learn to program in Scala.General programming knowledge is assumed.  [The Third Edition is now available](http://www.artima.com/shop/programming_in_scala_3ed) for purchase. It has been updated to cover new features up to and including Scala version 2.12 
 [Scala Standard Documentation](http://www.scala-lang.org/documentation/) | [EPFL](http://www.epfl.ch/) | [Getting Strarted](http://www.scala-lang.org/documentation/getting-started.html), [Overviews/Guides](http://docs.scala-lang.org/overviews/), [Tutorials](http://docs.scala-lang.org/tutorials/), [API - Scaladocs](http://www.scala-lang.org/documentation/api.html), [Language Specification](http://www.scala-lang.org/files/archive/spec/2.11/), [Glossary](http://docs.scala-lang.org/glossary/), [Cheatsheets](http://docs.scala-lang.org/cheatsheets/), [Style Guide](http://docs.scala-lang.org/style/), and more.
-[Essential Scala - Six Core Concepts for Learning Scala](http://downloads.typesafe.com/website/presentations/ScalaDaysSF2015/essential-scala.pdf) - PDF | [Underscore](http://underscore.io/) | Presentation slide deck from Scala Days SF 2015 that is overview of Underscore's Essential Scala course.
+[A Tour of Scala](http://docs.scala-lang.org/tutorials/tour/tour-of-scala)|[EPFL](http://www.epfl.ch/)|Bite-size pieces of the essentials.
+[Programming in Scala, 1st Edition](http://www.artima.com/pins1ed/) - free online | [Martin Odersky](https://en.wikipedia.org/wiki/Martin_Odersky), [Lex Spoon](http://www.lexspoon.org/), and [Bill Venners](http://www.scala-lang.org/blog/2016/04/29/sc-community-representative.html) | The "Stairway" Book - This book is the authoritative "step-by-step" tutorial on the Scala programming language, co-written by the language's designer, Martin Odersky. The main target audience for this book is programmers who want to learn to program in Scala.General programming knowledge is assumed.  [The Third Edition is now available](http://www.artima.com/shop/programming_in_scala_3ed) for purchase. It has been updated to cover new features up to and including Scala version 2.12
+[About Scala and Scala Tutorial](http://stackoverflow.com/tags/scala/info)|[stackoverflow](http://stackoverflow.com/)|An aggregate of stackoverflow questions, plus links to other resources. An online book of information.
+[Learning Scala in Small Bites](http://matt.might.net/articles/learning-scala-in-small-bites/)|[Matt Might](http://matt.might.net/)|To help learn Scala faster, a series of small examples, each of which highlights one or two aspects of the language.
+[The Beginner's Guide to Learning Scala](http://guides.co/g/how-to-learn-scala/27734)|[Bold Radius](http://boldradius.com/) |This step-by-step guide will walk you through learning Scala from scratch on your own. We've pulled together the best, most trusted resources from industry experts on each topic to make sure that you're spending your time efficiently and learning Scala the right way.
+[Scala Cookbook](http://scalacookbook.com/)|[Alvin Alexander](http://alvinalexander.com/)|Contains direct links to [Scala Cookbook](http://shop.oreilly.com/product/0636920026914.do) recipes, which are now available on author's website. 
+[Atomic Scala](http://www.atomicscala.com/) |[Mindview](http://www.mindviewinc.com/Index.php) | This book teaches the Scala language to both programming beginners and those who have already programmed in another language. The first 100+ pages of the book are available as a PDF download.
+[Scala Programming for Data Science](https://bigdatauniversity.com/learn/scala/)|[Big Data University](https://bigdatauniversity.com/)|Free training from Lightbend for "aspiring or seasoned Data Scientist (or Data Engineer) who is planning to work with Apache Spark to tackle Big Data with ease."
+[Creative Scala](http://underscore.io/training/courses/creative-scala/) | [Underscore](http://underscore.io/) | Creative Scala is aimed at developers who have no prior experience in Scala. It is designed to give you a fun introduction to functional programming. The course textbook is free, complete with exercises and solutions.
+[LearnXinYMinutes where X=Scala](https://learnxinyminutes.com/docs/scala/)|[LearnXinYMinutes](https://learnxinyminutes.com/)|Take a whirlwind tour of Scala. Community-driven!
+[Ninety-Nine Scala Problems](http://aperiodic.net/phil/scala/s-99/)|[Phil Gold](http://aperiodic.net/phil/)|An adaptation of the Ninety-Nine Prolog Problems written by Werner Hett at the Berne University of Applied Sciences in Berne, Switzerland, altered to be more amenable to programming in Scala.
+[Scala Koans](http://www.scalakoans.org/)|[Scala Koans](http://scalakoans.webfactional.com/contributors)|Koans are small lessons on the path to enlightenment. The aim of the Scala Koans project is to provide an easy learning environment in Scala. Your insight will be derived by encountering failing tests and fixing them so that they pass. A testing framework is used to simplify this process and to get you off to a good start with using Scala.
+[Getting Started with Scala Tutorial](https://blog.udemy.com/scala-tutorial-getting-started-with-scala/)|[udemy blog](https://blog.udemy.com/)|Basic Scala Introduction using IntelliJ IDEA. Includes setup instructions for IDEA.
+[Scala for the Impatient](http://horstmann.com/scala/) | [Cay S. Horstmann](http://horstmann.com/) | A rapid introduction to Scala for programmers who are competent in Java, C#, or C++. “Currently the best compact introduction to Scala” —Martin Odersky [Lightbend](https://www.lightbend.com/resources/e-book/scala-for-the-impatient) provides a free download of Chapters 1-11, 139 pages. Chapters 14, 16, 17, 19 are also [available](http://cayhorstmann.github.io/heigvd-scala-spring2015/).
+[12 ScalaTest tutorials](http://alvinalexander.com/scala/scalatest-tutorials-from-scala-cookbook)|[Alvin Alexander](http://alvinalexander.com/)|12 Scalatest tutorials that didn't make it into Scala Cookbook
+[Scala Best Practices](https://github.com/alexandru/scala-best-practices)|[Alexandru Nedelcu](https://github.com/alexandru)|A collection of best practices, friendly to people that want to contribute.
+[Scala Cheatsheet](http://mbonaci.github.io/scala/)|[Marko Bonaći](https://github.com/mbonaci)|One huge Scala reference card. Based on Programming in Scala, 2nd edition.
+[Scala Cheatsheet](http://worldline.github.io/scala-cheatsheet/)|[GitHub Repo](https://github.com/worldline/scala-cheatsheet)|CheatSheet for the scala language
+[Resources for Getting Started with Functional Programming and Scala](http://nerd.kelseyinnis.com/blog/2013/01/07/resources-for-getting-started-with-functional-programming-and-scala/)|[Kelsey Innis](http://nerd.kelseyinnis.com)| This is the “secret slide” from my recent talk [Learning Functional Programming without Growing a Neckbeard](http://nerd.kelseyinnis.com/blog/2012/12/17/slides-from-learning-functional-programming-without-growing-a-neckbeard/), with links to the sources I used to put the talk together and some suggestions for ways to get started writing Scala code.
+[Scala exercises at exercism.io](http://exercism.io/languages/scala/exercises)|[exercism.io](exercism.io)|Download and solve practice problems. Submit the solution to the site for feedback. For code newbies and experienced programmers.
+## Free Intermediate Resources
+Resource | Source | Description
+---|---|---
 [Scala by Example](http://www.scala-lang.org/docu/files/ScalaByExample.pdf) - PDF | [EPFL](http://www.epfl.ch/) | Takes you through the Scala features with many examples. It does assume that you are already familiar with the basic Scala syntax and a basic understanding of functional programming. It is an excellent way to expand your knowledge and skill.
-["Learn Functional Programming Without Growing a Neckbeard"](https://www.youtube.com/watch?v=OOvL6QAxRK4) | [Kelsey Innis](http://nerd.kelseyinnis.com/blog/2013/01/07/resources-for-getting-started-with-functional-programming-and-scala/) | With the help of Pam Grier, Kelsey Innis, software engineer at StackMob, hopes to take functional programming away from the of holier-than-thou neckbeards and bring it to the mere mortals. - YouTube video recorded at SF Scala meetup in December 2012.
+[The Neophyte's Guide to Scala](http://danielwestheide.com/scala/neophytes.html)|[Daniel Westheide](http://danielwestheide.com/) |A blog series targeted at aspiring Scala enthusiasts who have already made their first steps with the language and are looking for more detailed explanations.
+[Coursera Scala Specialization](https://www.coursera.org/specializations/scala) | [Scala Center](https://scala.epfl.ch/) | A new Scala mini-degree offered on Coursera. Composed of: 4 courses, one capstone project - A significant 4-5 week long final programming project. Note: only the first 3 courses are currently available.
+[Scala Tutorial Through Katas](https://technologyconversations.com/2014/03/10/scala-tutorial-through-katas/)|[Victor Farcic](https://technologyconversations.com/about)|A programming kata is an exercise which helps a programmer hone his skills through practice and repetition.
+## Free Advanced Resources
+Resource | Source | Description
+---|---|---
+[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala) | [Paul Chiusano](https://pchiusano.github.io/) and [Rúnar Bjarnason](http://blog.higher-order.com/) | Functional Programming in Scala is a serious tutorial for programmers looking to learn FP and apply it to the everyday business of coding. [Lightbend](https://www.lightbend.com/resources/e-book/functional-programming-in-scala) provides 2 sample chapters for free and a promotional 40% off the purchase price at Manning.
+## Paid Introductory Resources 
+Resource | Source | Description
+---|---|---
+[udemy Scala courses](https://www.udemy.com/courses/search/?q=scala&src=ukw&pm_value=0&sort=highest-rated)|[udemy](www.udemy.com)|Search results for all Scala courses
+[Introduction to Scala](https://www.scalacourses.com/showCourse/40)| [ScalaCourses.com](https://www.scalacourses.com/)|This Introduction to Scala course covers the fundamentals and is designed to give you a variety of hands-on experiences with Scala. The unique features of Scala are introduced, including object-oriented and functional aspects. Software tools are discussed in detail, including SBT, both leading IDEs (IntelliJ IDEA and Scala-IDE), and several options for programming Scala without an IDE. Exercises are provided throughout that reinforce the lecture material.
+## Paid Intermediate Resources 
+Resource | Source | Description
+---|---|---
+[Books, Videos, and Training Courses at underscore](http://underscore.io/training/)| [Underscore](http://underscore.io/) | A variety of books, videos and training classes, including Essential Scala, Advanced Scala with Cats, Essential Shapeless, Essential Play, Essential Slick, Essential Lift, Essential Distributed Systems, and Essential Scala Macros.
+[Programming Scala, 2nd Edition](https://deanwampler.github.io/books/programmingscala2.html)|[Dean Wampler](https://deanwampler.github.io/index.html)|A comprehensive and up-to-date introduction to Scala. It covers the features of Scala version 2.11.
+[Intermediate Scala](https://www.scalacourses.com/showCourse/45)| [ScalaCourses.com](https://www.scalacourses.com/)|This Intermediate Scala course builds on the Introduction to Scala course. Many concepts and techniques are introduced, with lots of working code examples and exercises, including functional programming, implicits, process control, I/O, collections, pattern matching, combinators, partial functions, application configuration techniques, memoization, and multithreading (including parallel collections, Futures, Promises and Akka Actors).
+[Modern Web Development with Scala](https://leanpub.com/modern-web-development-with-scala)|[Denis Kalinin](https://github.com/denisftw)|This book takes a very practical approach to teaching Scala. It begins by showing you just enough basics to get started and then guides you through the process of building a technology-packed real-world Web application using popular backend and frontend technologies.
+## Paid Advanced Resources 
+Resource | Source | Description
+---|---|---
+[Functional Programming in Scala](https://www.manning.com/books/functional-programming-in-scala) | [Paul Chiusano](https://pchiusano.github.io/) and [Rúnar Bjarnason](http://blog.higher-order.com/) | Functional Programming in Scala is a serious tutorial for programmers looking to learn FP and apply it to the everyday business of coding. [Lightbend](https://www.lightbend.com/resources/e-book/functional-programming-in-scala) provides 2 sample chapters for free and a promotional 40% off the purchase price at Manning.
+[Mastering Advanced Scala](https://leanpub.com/modern-web-development-with-scala)|[Denis Kalinin](https://github.com/denisftw)|This book goes beyond simple Scala usage and covers some advanced topics. It explores techniques and libraries that are usually considered non-trivial and shows why they are useful in real projects.
+[Introduction to Play Framework for Scala](https://www.scalacourses.com/showCourse/39)| [ScalaCourses.com](https://www.scalacourses.com/)|This "Introduction to Play with Scala" course covers the fundamentals of Play Framework for Scala programmers. Exercises are provided throughout that reinforce the lecture material. The material builds from lecture to lecture, so be sure to go through the material from start to finish. Several complete working sample Play Framework projects are provided and discussed in detail.
+# Other Information Resources
+## Online Coding
+Resource | Source | Description
+---|---|---
+[ScalaFiddle](https://scalafiddle.io/sf/gKgxQY0/1)| |ScalaFiddle is an online playground for writing and sharing Scala code.
+[ScalaFiddle](http://scalafiddle.net/info)| |Provides online scala console
+[Scala Kata](http://www.scalakata.com/)|[Guillaume Massé](https://github.com/MasseGuillaume)|Scala Kata is an interactive playground.
+## Blogs and Newsletters
+Resource | Source | Description
+---|---|---
+This week in #Scala|[Cake Solutions Team Blogs](http://www.cakesolutions.net/teamblogs)|This blog aims to keep you up to date with the latest news from the world of Scala and Reactive programming.
+[Scala Tutorials](https://www.javacodegeeks.com/tutorials/scala-tutorials/)|[Java Code Geeks](https://www.javacodegeeks.com/)|Scala Tutorial Blog Posts
+## References
+Resource | Source | Description
+---|---|---
+[Awesome Scala at Libhunt](https://scala.libhunt.com/)|[LibHunt](https://www.libhunt.com/)|Awesome Scala is a community effort. The primary listings are based on the Scala Community listed [Awesome Scala list at GitHub](https://github.com/lauris/awesome-scala). Also home of [Awesome Scala Newsletter](https://scala.libhunt.com/newsletter/).
+[Scala Coding Style Guide](https://github.com/databricks/scala-style-guide)|[Databricks](https://databricks.com/)|This guide draws from our experience coaching and working with engineers contributing to Spark as well as our Databricks engineering team.
+[Lightbend e-Books](http://www.lightbend.com/resources/e-books)|[Lightbend](www.lightbend.com)|A variety of free e-books and chapter downloads
+[Scala on Zeef](https://scala.zeef.com/ivano.pagano)|[Ivano Pagano at Zeef](https://zeef.com/profile/ivano.pagano)|This aims to be a comprehensive reference to all scala-related resources I collected through the years. Look elsewhere if you need a shorter or more focused compendium.
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+


### PR DESCRIPTION
Updated resources.md to show different levels on training resources. Since github markdown does not support color, used headings to break out different categories. Used link to Scala Community page and made our resources "additional", i.e. no duplication of community page links.

Will need to create HTML page to add color coding for this information.
