### PR TITLE
fix example `draw` command

### DIFF
--- a/setup/mac.md
+++ b/setup/mac.md
@@ -52,7 +52,7 @@ $ ./sbt.sh
 . (you'll see some [info] logs here)
 .
 .
-scala> Example.image.draw
+scala> Example.image.draw()
 ```
 
 An image of three circles should appear!


### PR DESCRIPTION
when I ran it locally (on the current https://github.com/underscoreio/creative-scala-template/archive/master.zip), I got an error:

```
scala> Example.image.draw
<console>:42: error: could not find implicit value for parameter renderer: doodle.effect.DefaultRenderer[[x[_]]doodle.language.Basic[x],Nothing,Nothing,Nothing]
       Example.image.draw
                     ^
```

changing to `draw()` seems to fix